### PR TITLE
Fix saving stl

### DIFF
--- a/pymesh/base.py
+++ b/pymesh/base.py
@@ -212,7 +212,7 @@ class BaseMesh(object):
     # STL
     def save_stl(self, path, mode=MODE_STL_AUTO, update_normals=True):
         """Save data with stl format
-        :param str paht:
+        :param str path:
         :param int mode:
         :param bool update_normals:
         """

--- a/pymesh/base.py
+++ b/pymesh/base.py
@@ -237,8 +237,8 @@ class BaseMesh(object):
         else:
             raise ValueError("Mode %r is invalid" % mode)
 
-        with open(name, 'wb') as fh:
-            save_func(fh, filename)
+        with open(filename, 'wb') as fh:
+            save_func(fh, name)
 
     def __save_stl_binary(self, fh, name):
         fh.write(("%s (%s) %s %s" % (

--- a/pymesh/base.py
+++ b/pymesh/base.py
@@ -210,16 +210,16 @@ class BaseMesh(object):
     #
 
     # STL
-    def save_stl(self, filename, mode=MODE_STL_AUTO, update_normals=True):
+    def save_stl(self, path, mode=MODE_STL_AUTO, update_normals=True):
         """Save data with stl format
-        :param str filename:
+        :param str paht:
         :param int mode:
         :param bool update_normals:
         """
         if update_normals:
             self.update_normals()
 
-        name = os.path.split(filename)[-1]
+        filename = os.path.split(path)[-1]
 
         if mode is MODE_STL_AUTO:
             if self.mode == MODE_STL_BINARY:
@@ -237,8 +237,8 @@ class BaseMesh(object):
         else:
             raise ValueError("Mode %r is invalid" % mode)
 
-        with open(filename, 'wb') as fh:
-            save_func(fh, name)
+        with open(path, 'wb') as fh:
+            save_func(fh, filename)
 
     def __save_stl_binary(self, fh, name):
         fh.write(("%s (%s) %s %s" % (
@@ -268,9 +268,9 @@ class BaseMesh(object):
         print("endsolid {}".format(name), file=fh)
 
     # OBJ
-    def save_obj(self, filename, update_normals=True):
+    def save_obj(self, path, update_normals=True):
         """Save data with OBJ format
-        :param stl filename:
+        :param stl path:
         :param bool update_normals:
         """
         if update_normals:
@@ -305,7 +305,7 @@ class BaseMesh(object):
             # print(normals_list)
             triangle_list.append((one_triangle, n_index + 1))
 
-        with open(filename, "wb") as fh:
+        with open(path, "wb") as fh:
             print("# {} {}".format(__title__, __version__), file=fh)
             print("# {}".format(datetime.datetime.now()), file=fh)
             print("# {}".format(__url__), file=fh)

--- a/pymesh/obj.py
+++ b/pymesh/obj.py
@@ -13,22 +13,22 @@ class Obj(BaseMesh):
         ('attr', numpy.uint16, (1, )),
     ])
 
-    def __init__(self, filename=None):
+    def __init__(self, path=None):
         """Create an instance of Obj (Wavefront)
-        :param str filename:
+        :param str path:
         """
         super(Obj, self).__init__()
 
-        if filename is None:
+        if path is None:
             # Create EMPTY data
             self.name = "empty"
             self.data = numpy.zeros(0, dtype=Obj.obj_dtype)
 
         else:
             # Create data from file
-            with open(filename, "rb") as fh:
+            with open(path, "rb") as fh:
                 data = Obj.__load(fh)
-            self.name = filename
+            self.name = path
             self.data = data
 
         super(Obj, self).set_initial_values()

--- a/pymesh/stl.py
+++ b/pymesh/stl.py
@@ -24,14 +24,14 @@ class Stl(BaseMesh):
         ('attr', numpy.uint16, (1, )),
     ])
 
-    def __init__(self, filename=None, mode_policy=MODE_AUTO):
+    def __init__(self, path=None, mode_policy=MODE_AUTO):
         """Craete a instance of Stl.
-        :param str filename: The filename to open
+        :param str path: The file path to open
         :param int mode_policy: The mode to open, default is :py:data:`AUTOMATIC`.
         """
         super(Stl, self).__init__()
 
-        if filename is None:
+        if path is None:
             # Create EMPTY data
             self.name = "empty"
             self.data = numpy.zeros(0, dtype=Stl.stl_dtype)
@@ -39,7 +39,7 @@ class Stl(BaseMesh):
 
         else:
             # Create data from file
-            with open(filename, "rb") as fh:
+            with open(path, "rb") as fh:
                 name, data, mode = Stl.__load(fh, mode=mode_policy)
             self.name = name
             self.data = data


### PR DESCRIPTION
STL files were not saved under right path
`save_stl` was passing file path to stl `save_func` and was using filename as file path
I've also renamed `filename` to `path` to avoid confusing it with `name` written into files
